### PR TITLE
don't let WinRPM prompt

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,7 +2,7 @@ using Compat
 
 @windows_only begin
     using WinRPM
-    WinRPM.install("libfreetype6")
+    WinRPM.install("libfreetype6", yes=true)
 end
 
 const freetype = Libdl.find_library(


### PR DESCRIPTION
Without it, it won't install properly on windows.
This is unfortunate since we just tagged, but it can't be helped ... I'll try to fix this in METADATA.
