### PR TITLE
Update compat for CEnum

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 FreeType2_jll = "d7e528f0-a631-5988-bf34-fe36492bcfd7"
 
 [compat]
-CEnum = "0.2"
+CEnum = "0.2,0.3,0.4"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
My system got CENum v0.4.1 installed, and then installing GLMakie and AbstractPlotting gave me old versions of FreeType v2.1.1, AbstractPlotting v0.9.27, GLMakie v0.0.18.