### PR TITLE
Relax compat with FreeType2_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FreeType"
 uuid = "b38be410-82b0-50bf-ab77-7b57e271db43"
-version = "4.1.0"
+version = "4.1.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -8,7 +8,7 @@ FreeType2_jll = "d7e528f0-a631-5988-bf34-fe36492bcfd7"
 
 [compat]
 CEnum = "0.2,0.3,0.4"
-FreeType2_jll = "~2.10"
+FreeType2_jll = "2.10"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
Allow all versions in the v2 series.

This overly restrictive compat bound is causing lots of problems in the ecosystem:

* https://github.com/MakieOrg/Makie.jl/issues/3123
* https://github.com/jheinen/GR.jl/issues/525
* https://discourse.julialang.org/t/error-in-precompiling-ffmpeg-and-cairo-and-cairomakie/102461
* https://discourse.julialang.org/t/plots-jl-and-cairo-makie-not-compatible/102509

CC: @SimonDanisch